### PR TITLE
Speed up panel2cs2

### DIFF
--- a/BMisc.Rproj
+++ b/BMisc.Rproj
@@ -5,7 +5,12 @@ SaveWorkspace: No
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 4
 Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
 
 AutoAppendNewline: Yes
 StripTrailingWhitespace: Yes

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,6 +5,7 @@ Authors@R: person("Brantly", "Callaway", email = "brantly.callaway@uga.edu", rol
 Description: These are miscellaneous functions for working with panel data, quantiles, and printing results.  For panel data, the package includes functions for making a panel data balanced (that is, dropping missing individuals that have missing observations in any time period), converting id numbers to row numbers, and to treat repeated cross sections as panel data under the assumption of rank invariance.  For quantiles, there are functions to make distribution functions from a set of data points (this is particularly useful when a distribution function is created in several steps), to combine distribution functions based on some external weights, and to invert distribution functions.  Finally, there are several other miscellaneous functions for obtaining weighted means, weighted distribution functions, and weighted quantiles; to generate summary statistics and their differences for two groups; and to add or drop covariates from formulas.
 Depends: R (>= 2.1.0)
 Imports: 
+    data.table,
     Rcpp,
     tidyr
 License: GPL-2

--- a/R/utils-data-table.R
+++ b/R/utils-data-table.R
@@ -1,0 +1,12 @@
+# data.table is generally careful to minimize the scope for namespace
+# conflicts (i.e., functions with the same name as in other packages);
+# a more conservative approach using @importFrom should be careful to
+# import any needed data.table special symbols as well, e.g., if you
+# run DT[ , .N, by='grp'] in your package, you'll need to add
+# @importFrom data.table .N to prevent the NOTE from R CMD check.
+# See ?data.table::`special-symbols` for the list of such symbols
+# data.table defines; see the 'Importing data.table' vignette for more
+# advice (vignette('datatable-importing', 'data.table')).
+#
+#' @import data.table
+NULL


### PR DESCRIPTION
I realized that panel2cs2  first orders by id and year so you can just use a lag operator instead of having to pivot wide and remerge. panel2cs2 was taking up about a third of a typical att_gt call.

With 155k observations:
Before the changes: 21.75s
After the changes: 17.58s

About a 18% reduction in run time

With 3100 observations:
Before the changes: 5.83s
After the changes: 3.8s

About a 53% reduction in run time

```r
library(profvis)
library(did)
library(data.table)

gen_data <- function(g1 = 2000, g2 = 2010, g3 = 0, panel = c(1990, 2020), te1 = 2, te2 = 2, te3 = 2, te_m1 = 0, te_m2 = 0, te_m3 = 0) {

    n = 5000

    df = tibble::tibble(unit = 1:n)

    df$state = sample(1:40, n, replace = TRUE)
    df$unit_fe = stats::rnorm(n, df$state/5, 1)

    df$group = stats::runif(n)
    df$group = dplyr::case_when(
        df$group < 0.33 ~ "Group 1",
        df$group < 0.66 ~ "Group 2",
        TRUE ~ "Group 3"
    )
    df$g = dplyr::case_when(
        df$group == "Group 1" ~ g1,
        df$group == "Group 2" ~ g2,
        df$group == "Group 3" ~ g3,
    )

    # Make into panel
    nyear <- panel[2] - panel[1] + 1
    df = df[rep(1:nrow(df), times = nyear), ]
    df$year <- rep(panel[1]:panel[2], each = n)

    # Add year FE
    year_fe = tibble::tibble(year = panel[1]:panel[2])
    year_fe$year_fe = stats::rnorm(length(year_fe$year), 0, 1)

    # Join with year_fe tibble
    df = dplyr::left_join(df, year_fe, by = "year")

    df$treat = (df$year >= df$g) & (df$g %in% panel[1]:panel[2])

    df$rel_year = dplyr::if_else(df$g == 0L, Inf, as.numeric(df$year - df$g))

    df$rel_year_binned = dplyr::case_when(
        df$rel_year == Inf ~ Inf,
        df$rel_year <= -6 ~ -6,
        df$rel_year >= 6 ~ 6,
        TRUE ~ df$rel_year
    )

    df$error = stats::rnorm(nrow(df), 0, 1)

    # Level Effect
    df$te =
        (df$group == "Group 1") * te1 * (df$year >= g1) +
        (df$group == "Group 2") * te2 * (df$year >= g2) +
        (df$group == "Group 3") * te3 * (df$year >= g3)
    # dynamic Effect
    df$te_dynamic =
        (df$group == "Group 1") * (df$year >= g1) * te_m1 * (df$year - g1) +
        (df$group == "Group 2") * (df$year >= g2) * te_m2 * (df$year - g2) +
        (df$group == "Group 3") * (df$year >= g3) * te_m3 * (df$year - g3)

    df$dep_var = df$unit_fe + df$year_fe + df$te + df$te_dynamic + df$error

    return(df)
}

data = gen_data(panel = c(1990, 2020), g1 = 2000, g2 = 2010, g3 = 0, te1 = 2, te2 = 2, te3 = 0, te_m1 = 0, te_m2 = 0, te_m3 = 0)

setDT(data)

# More g to see if it slows down did
data[, g := sample(c(0, 2000:2015), .N, replace = T)]

# unique ID
data[, id := .GRP, by = .(state, unit)]



profvis::profvis({
    att_gt(
        yname = "dep_var", idname = "id", tname = "year", gname = "g",
        data = as.data.frame(data)
    )
})
```

