### PR TITLE
plm nosuggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: BMisc
 Title: Miscellaneous Functions for Panel Data, Quantiles, and Printing Results
-Version: 1.4.4
+Version: 1.4.5
 Authors@R: person("Brantly", "Callaway", email = "brantly.callaway@uga.edu", role = c("aut", "cre"))
 Description: These are miscellaneous functions for working with panel data, quantiles, and printing results.  For panel data, the package includes functions for making a panel data balanced (that is, dropping missing individuals that have missing observations in any time period), converting id numbers to row numbers, and to treat repeated cross sections as panel data under the assumption of rank invariance.  For quantiles, there are functions to make distribution functions from a set of data points (this is particularly useful when a distribution function is created in several steps), to combine distribution functions based on some external weights, and to invert distribution functions.  Finally, there are several other miscellaneous functions for obtaining weighted means, weighted distribution functions, and weighted quantiles; to generate summary statistics and their differences for two groups; and to add or drop covariates from formulas.
-Depends: R (>= 2.1.0)
+Depends: R (>= 3.1.0)
 Imports: 
     data.table,
     Rcpp

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# BMisc 1.4.5
+  
+  * only execute examples for `subsample` and `blockBootSample` if `plm` package is available (thanks Achim Zeileis)
+
 # BMisc 1.4.4
   
   * faster version of `panel2cs2` (thanks Kyle Butts)

--- a/R/BMisc.R
+++ b/R/BMisc.R
@@ -465,7 +465,7 @@ cs2panel <- function(cs1, cs2, yname) {
 #' @return matrix of results
 #' @export
 compareBinary <- function(x, on, dta, w=rep(1,nrow(dta)), report=c("diff","levels","both")) {
-  if (class(dta[,x]) == "factor") {
+  if (inherits(dta[,x], "factor")) {
     df <- model.matrix(as.formula(paste0("~",x,"-1")), dta)
     vnames <- colnames(df)
     df <- data.frame(cbind(df, dta[,on]))

--- a/R/BMisc.R
+++ b/R/BMisc.R
@@ -172,7 +172,11 @@ id2rownum <- function(id, data, idname) {
 #'  will contain new ids
 #'
 #' @examples
-#' data(LaborSupply, package="plm")
+#' \dontshow{ if(!requireNamespace("plm")) {
+#'   if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
+#'     stop("package 'plm' is required for this example")
+#'   } else q() }}
+#' data("LaborSupply", package="plm")
 #' bbs <- blockBootSample(LaborSupply, "id")
 #' nrow(bbs)
 #' head(bbs$id)
@@ -690,7 +694,11 @@ combineDfs <- function(y.seq, dflist, pstrat=NULL, ...) {
 #'  is not set); the default is the number of unique ids
 #'
 #' @examples
-#' data(LaborSupply, package="plm")
+#' \dontshow{ if(!requireNamespace("plm")) {
+#'   if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
+#'     stop("package 'plm' is required for this example")
+#'   } else q() }}
+#' data("LaborSupply", package="plm")
 #' nrow(LaborSupply)
 #' unique(LaborSupply$year)
 #' ss <- subsample(LaborSupply, "id", "year", nkeep=100)

--- a/man/blockBootSample.Rd
+++ b/man/blockBootSample.Rd
@@ -20,7 +20,11 @@ make draws of all observations with the same id in a panel
  data context.  This is useful for bootstrapping with panel data.
 }
 \examples{
-data(LaborSupply, package="plm")
+\dontshow{ if(!requireNamespace("plm")) {
+  if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
+    stop("package 'plm' is required for this example")
+  } else q() }}
+data("LaborSupply", package="plm")
 bbs <- blockBootSample(LaborSupply, "id")
 nrow(bbs)
 head(bbs$id)

--- a/man/subsample.Rd
+++ b/man/subsample.Rd
@@ -27,7 +27,11 @@ returns a subsample of a panel data set; in particular drops
  randomly keeps \code{nkeep} observations.
 }
 \examples{
-data(LaborSupply, package="plm")
+\dontshow{ if(!requireNamespace("plm")) {
+  if(interactive() || is.na(Sys.getenv("_R_CHECK_PACKAGE_NAME_", NA))) {
+    stop("package 'plm' is required for this example")
+  } else q() }}
+data("LaborSupply", package="plm")
 nrow(LaborSupply)
 unique(LaborSupply$year)
 ss <- subsample(LaborSupply, "id", "year", nkeep=100)


### PR DESCRIPTION
Package `BMisc` was archived on CRAN because it uses `plm` in some examples unconditionally. Thus, if `plm` is not available these examples fail with an error.

To address this problem I've added a short header in the examples (not shown to the end-user) that checks whether `plm` is available. If not, the examples are not executed. When run interactively or not in R CMD check an informative error is thrown, otherwise R quits (from this and all subsequent examples). The latter is a bit harsh but makes the package pass R CMD check again and the former should be informative for all other users.

Additionally, I corrected a [`class(.) == *` problem](https://blog.R-project.org/2019/11/09/when-you-think-class.-think-again/), increased the package version, and increased the dependency to R >= 3.1.0 (which is implied by the `data.table` dependency).

The package should be ready for resubmission to CRAN but you need to comment on the remaining NOTE because the package was archived and uses a URL (CRAN checks) which will only become available again when the package is on CRAN.

Please also re-release the packages that were archived due to their `BMisc` dependency (`did`, `qte`( and inform the authors of `DRDID` (which I believe you know and are in contact with).