### PR TITLE
3x speedup of `multiplier_bootstrap`

### DIFF
--- a/src/BMisc.cpp
+++ b/src/BMisc.cpp
@@ -59,14 +59,13 @@ void fill_rademacher(arma::vec &v)
   // Calculate the number of integers needed based on N
   int num_integers = ceil(n / 31.0);
 
-  // 2^31 - 1 = 2147483647
-  IntegerVector random_integer = Rcpp::sample(2147483647, num_integers, true);
-
   int k = 0;
   int J = 30;
+  int curr;
   for (int i = 0; i < num_integers - 1; ++i)
   {
-    int curr = random_integer[i];
+    // 2^31 - 1 = 2147483647
+    curr = Rcpp::sample(2147483647, 1)[0];
 
     for (int j = J; j >= 0; j--)
     {
@@ -76,9 +75,10 @@ void fill_rademacher(arma::vec &v)
   }
 
   int j = J;
+  curr = Rcpp::sample(2147483647, 1)[0];
   for (; k < n; ++k, --j)
   {
-    v[k] = ((random_integer[num_integers - 1] >> j) & 1) * 2 - 1;
+    v[k] = ((curr >> j) & 1) * 2 - 1;
   }
 }
 


### PR DESCRIPTION
Updated PR. I got curious again and got a 3x speed-up for `multiplier_bootstrap` making `did` 2x faster. 🔮🪄

## `multiplier_bootstrap` raw performance

>3x improvement

``` r
nrow = 10000
ncol = 20
inf_func = matrix(runif(nrow * ncol), nrow = nrow, ncol = ncol)

bench::mark(
  orig = BMisc::multiplier_bootstrap(inf_func, 50),
  v2 = BMisc::multiplier_bootstrap_new(inf_func, 50),
  check = FALSE
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 orig         45.3ms   46.9ms      21.3     6.8MB        0
#> 2 v2           14.5ms   14.7ms      66.8      79KB        0

nrow = 50000
ncol = 50
inf_func = matrix(runif(nrow * ncol), nrow = nrow, ncol = ncol)

bench::mark(
  orig = BMisc::multiplier_bootstrap(inf_func, 50),
  v2 = BMisc::multiplier_bootstrap_new(inf_func, 50),
  check = FALSE
)
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 orig          548ms    548ms      1.83    22.1KB        0
#> 2 v2            172ms    173ms      5.78   339.6KB        0
```


## Implication for `did`

This lets `did` run in half the time

Before: 

``` r
# Implications for `did` package
library(did)

set.seed(1)
time.periods <- 15
n <- 30000

# unit data
id <- 1:n
group <- sample(seq(10,16), n, replace=TRUE)
unit_data <- data.frame(id=id, group=group)

# generate panel data
panel_data <- data.frame(id=sort(rep(id,time.periods)),
                         tp=rep(rep(1:time.periods),n))
panel_data <- merge(panel_data, unit_data, by="id")
panel_data$D <- 1*(panel_data$tp >= panel_data$group)

# generate heterogeneous treatment effects by calendar date
tau <- (panel_data$D==1)*(panel_data$tp - 12.5)
panel_data$Y <- panel_data$id + 3*panel_data$tp +
  tau*panel_data$D + rnorm(nrow(panel_data))

# with 1000 bootstrap iterations
tictoc::tic()
out <- att_gt(yname="Y",
              gname="group",
              idname="id",
              tname="tp",
              data=panel_data,
              bstrap=TRUE,
              biters=1000)
dyn <- aggte(out, type="dynamic")
tictoc::toc()
#> 33.679 sec elapsed
```

After: 
``` r
library(did)

set.seed(1)
time.periods <- 15
n <- 30000

# unit data
id <- 1:n
group <- sample(seq(10,16), n, replace=TRUE)
unit_data <- data.frame(id=id, group=group)

# generate panel data
panel_data <- data.frame(id=sort(rep(id,time.periods)),
                         tp=rep(rep(1:time.periods),n))
panel_data <- merge(panel_data, unit_data, by="id")
panel_data$D <- 1*(panel_data$tp >= panel_data$group)

# generate heterogeneous treatment effects by calendar date
tau <- (panel_data$D==1)*(panel_data$tp - 12.5)
panel_data$Y <- panel_data$id + 3*panel_data$tp +
  tau*panel_data$D + rnorm(nrow(panel_data))

# with 1000 bootstrap iterations
tictoc::tic()
out <- att_gt(yname="Y",
              gname="group",
              idname="id",
              tname="tp",
              data=panel_data,
              bstrap=TRUE,
              biters=1000)
dyn <- aggte(out, type="dynamic")
tictoc::toc()
#> 15.729 sec elapsed
```

